### PR TITLE
Small refactor for the credits section

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
         <li>Leon Chou: Puzzles &amp; Infrastructure (2020)</li>
         <li>Peter Collins: Infrastructure &amp; puzzles (2017)</li>
         <li>Manoj Dayaram: Infrastructure (2017)</li>
+        <li>Alex Epifano (2021)</li>
         <li>Stefan Filipek: Puzzles &amp; Infrastructure (2023)</li>
         <li>Kyle Fox:
           <div>Organizer (2020, 2021, 2022, 2023)</div>
@@ -103,12 +104,13 @@
         <li>Achintya Prakash: Infrastructure &amp; puzzles (2018, 2019)</li>
         <li>Alyssa Ransbury: Puzzles (2019)</li>
         <li>Mathew Rowley: Puzzles (2017)</li>
-        <li>Isaac Semaya: Puzzles (2020)</li>
+        <li>Isaac Semaya: Puzzles (2020, 2021)</li>
+        <li>Jay Smith: Puzzles (2021)</li>
         <li>Salvatore Testa: Puzzles &amp; creative writing (2017, 2019)</li>
         <li>Alice Wang: Puzzles (2017, 2018)</li>
         <li>Brian Wang: Puzzles (2017)</li>
         <li>Jared Windover: Design (2018)</li>
-        <li>Roy Xu: Puzzles (2019, 2020)</li>
+        <li>Roy Xu: Puzzles (2019, 2020, 2021)</li>
         <li>Bushi Zhang: Art work (2019)</li>
         <li>Chaoshun Zuo: Puzzles (2023)</li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,10 @@
         <li>Peter Collins: Infrastructure &amp; puzzles (2017)</li>
         <li>Manoj Dayaram: Infrastructure (2017)</li>
         <li>Stefan Filipek: Puzzles &amp; Infrastructure (2023)</li>
-        <li>Kyle Fox: Puzzles &amp; Infrastructure (2018, 2020, 2022, 2023)</li>
+        <li>Kyle Fox:
+          <div>Organizer (2020, 2021, 2022, 2023)</div>
+          <div>Puzzles &amp; Infrastructure (2018, 2020, 2021, 2022, 2023)</div>
+        </li>
         <li>Davis Gallinghouse: Puzzles (2015, 2016)</li>
         <li>Daniel Ge: Infrastructure (2018)</li>
         <li>Ross Glashan: Puzzles (2017, 2018)</li>
@@ -89,7 +92,10 @@
         <li>Will McChesney: Puzzles (2017)</li>
         <li>Matthew McPherrin: Prizes &amp; puzzles (2016, 2017)</li>
         <li>Jordan Mecom: Puzzles 2017 (2018)</li>
-        <li><a href="https://www.quaxio.com/">Alok Menghrajani</a>: Jack ∀ trades, master of ∅ (2015, 2016, 2017, 2018, 2019)</li>
+        <li><a href="https://www.quaxio.com/">Alok Menghrajani</a>:
+          <div>Organizer (2015, 2016, 2017, 2018, 2019)</div>
+          <div>Puzzles (2015, 2016, 2017, 2018, 2019, 2022)</div>
+        </li>
         <li>Dan Moore: Puzzles &amp; Infrastructure (2022)</li>
         <li>Murtaza Munaim: Puzzles (2017)</li>
         <li>Jesse Peirce: Workshop &amp; creative writing (2017, 2018)</li>


### PR DESCRIPTION
It's more accurate to split on two lines people who organized specific years and contributed puzzles in other years.